### PR TITLE
:recycle: Melhoria da função de "get_menor_contrato"

### DIFF
--- a/projeto.ipynb
+++ b/projeto.ipynb
@@ -52,7 +52,7 @@
         "\n",
         "c = ler_contratos_de_arquivo('entrada.txt')"
       ],
-      "execution_count": 1,
+      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
@@ -96,7 +96,7 @@
         "menor_contrato_periodo_completo = get_menor_contrato_periodo(c, 0, c.num_meses - 1)\n",
         "print(f'O fornecedor {menor_contrato_periodo_completo.fornecedor + 1} oferece o menor contrato do período completo, que custa: {menor_contrato_periodo_completo.valor:.2f}')\n"
       ],
-      "execution_count": 2,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",
@@ -128,18 +128,16 @@
       "source": [
         "def get_menor_contrato(c: Contratos) -> Contrato:\n",
         "    min_contrato = Contrato(c.num_fornecedores, c.num_meses, c.num_meses, inf)\n",
-        "\n",
-        "    for inicio in range(c.num_meses):\n",
-        "        for fim in range(c.num_meses):\n",
-        "            contrato = get_menor_contrato_periodo(c, inicio, fim)\n",
-        "            if contrato.valor < min_contrato.valor:\n",
-        "                min_contrato = contrato\n",
+        "    for mes in range(c.num_meses):\n",
+        "        contrato = get_menor_contrato_periodo(c, mes, mes)\n",
+        "        if contrato.valor < min_contrato.valor:\n",
+        "            min_contrato = contrato\n",
         "    return min_contrato\n",
         "\n",
         "menor_contrato = get_menor_contrato(c)\n",
         "print(f'O menor contrato é fornecido por {menor_contrato.fornecedor + 1}, do período ({menor_contrato.mes_inicio + 1}, {menor_contrato.mes_fim + 1}) pelo valor de {menor_contrato.valor:.2f}')"
       ],
-      "execution_count": 3,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "stream",
@@ -152,7 +150,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "**f)** Complexidade Θ(n^2 * m)"
+        "**f)** Complexidade Θ(m * n)"
       ]
     }
   ],


### PR DESCRIPTION
De acordo com a regra de negócio, nenhum contrato de 2, 3 ou n meses de duração terá
precificação melhor que a do contráto de um só mês de duração. Cientes disso,
podemos otimizar a função para iterar apenas pelos contratos de 1 mês de duração.